### PR TITLE
Bugfix for Issue #7

### DIFF
--- a/doc/help/scrub_deveny_pickup.rst
+++ b/doc/help/scrub_deveny_pickup.rst
@@ -12,8 +12,11 @@
     
     options:
       -h, --help           show this help message and exit
-      --proc_dir PROC_DIR  Path to the directory containing the .pypeit file used to
-                           process `file` (ldt_deveny_?) (default: None)
+      --proc_dir PROC_DIR  Path to the directory above that which contains the
+                           .pypeit file used to process `file` (i.e., the directory
+                           above ldt_deveny_?) -- use only if `-r` was used in the
+                           call to `pypeit_setup`. (default: current working
+                           directory)
       --overwrite_raw      Overwrite the raw file rather than create a new file with
                            the '_scrub' suffix (default: False)
       -d, --diagnostics    Output additional information and plots during the

--- a/obstools/scrub_deveny_pickup.py
+++ b/obstools/scrub_deveny_pickup.py
@@ -82,7 +82,7 @@ warnings.simplefilter("ignore", astropy.io.fits.verify.VerifyWarning)
 # Narrative Functions ========================================================#
 def iterative_pypeit_clean(
     filename: pathlib.Path,
-    proc_dir: str | pathlib.Path = None,
+    proc_dir: pathlib.Path = None,
     overwrite_raw: bool = False,
     diagnostics: bool = False,
     no_refit: bool = False,
@@ -100,7 +100,7 @@ def iterative_pypeit_clean(
     ----------
     filename : :obj:`~pathlib.Path`
         The name of the file to clean
-    proc_dir : :obj:`str` or :obj:`~pathlib.Path`, optional
+    proc_dir : :obj:`~pathlib.Path`, optional
         The location of the PypeIt-processed images, if not ``./ldt_deveny_?/``
         (Default: None)
     overwrite_raw : :obj:`bool`, optional


### PR DESCRIPTION
Fix for use of ``--proc_dir`` with the ``scrub_deveny_pickup`` script.

Fixes #7.

Clean up the searching for the associated ``spec2d`` PypeIt-processed file associated with the raw frame in question.

	modified:   doc/help/scrub_deveny_pickup.rst
	modified:   obstools/scrub_deveny_pickup.py
	modified:   obstools/utils.py