### PR TITLE
Allow Python 3.13

### DIFF
--- a/doc/scripts/write_script_help.py
+++ b/doc/scripts/write_script_help.py
@@ -35,7 +35,7 @@ def write_help(script_cls: utils.ScriptBase, opath: pathlib.Path, width: int = 8
     width : :obj:`int`, optional
         The width of the help text before wrapping  (Default: 80)
     """
-    exe = script_cls.name
+    exe = script_cls.name()
     ofile = os.path.join(opath, f"{exe}.rst")
     lines = [".. code-block:: console", ""]
     lines += [f"    $ {exe} -h"]

--- a/environment.yml
+++ b/environment.yml
@@ -2,4 +2,4 @@ name: obstools
 channels:
   - default
 dependencies:
-  - python>=3.10,<3.13
+  - python>=3.10,<3.14

--- a/obstools/__init__.py
+++ b/obstools/__init__.py
@@ -62,7 +62,7 @@ def script_classes() -> dict:
     scr_class = np.array(list(utils.all_subclasses(utils.ScriptBase)))
     print(scr_class)
 
-    scr_name = np.array([c.name for c in scr_class])
+    scr_name = np.array([c.name() for c in scr_class])
     # Construct a dictionary with the script name and class
     srt = np.argsort(scr_name)
     return dict(zip(scr_name[srt], scr_class[srt]))

--- a/obstools/utils.py
+++ b/obstools/utils.py
@@ -534,7 +534,6 @@ class ScriptBase:
         sys.exit(cls.main(args))
 
     @classmethod
-    @property
     def name(cls):
         """
         Provide the name of the script.  By default, this is the name of the

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
-#    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.13
     Topic :: Documentation :: Sphinx
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Software Development :: Libraries :: Python Modules
@@ -30,7 +30,7 @@ classifiers =
 zip_safe = False
 use_2to3=False
 packages = find:
-python_requires = >=3.10,<3.13
+python_requires = >=3.10,<3.14
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires =


### PR DESCRIPTION
Remove deprecated class property structure in the scripts; now should be good to go with Python 3.13.

	modified:   doc/scripts/write_script_help.py
	modified:   environment.yml
	modified:   obstools/__init__.py
	modified:   obstools/utils.py
	modified:   setup.cfg