### PR TITLE
Align `dev` tests with PypeIt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,12 @@ requires =
     setuptools >= 65.0
     pip >= 22.0
 isolated_build = true
-indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 # Suppress display of matplotlib plots generated during docs build
 setenv = MPLBACKEND=agg
+    numpydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    astropydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI
@@ -41,7 +41,7 @@ deps =
 
     cov: coverage
     numpydev: numpy>=0.0.dev0
-    astropydev: git+https://github.com/astropy/astropy.git#egg=astropy
+    astropydev: astropy>=0.0.dev0
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
@@ -49,7 +49,6 @@ extras =
     alldeps: pyyaml,stomp.py,xmltodict,obstools
 
 commands =
-    numpydev: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     !cov: pytest --pyargs obstools {posargs}
     cov: pytest --pyargs obstools --cov obstools --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
Align the way we do `numpydev` and `astropydev` tests with PypeIt, which itself it aligned with AstroPy.
